### PR TITLE
Aplica tema após mount, inicia em dark mode

### DIFF
--- a/components/Tema/TemaWrapper.tsx
+++ b/components/Tema/TemaWrapper.tsx
@@ -3,8 +3,12 @@ import { PropsWithChildren, useEffect, useState } from "react";
 import { BotaoTema, Temas } from "../BotaTema";
 
 export const TemaWrapper = (props: PropsWithChildren) => {
-  const temaDoNavegador = window?.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light';
-  const [tema, setTema] = useState<Temas>(localStorage?.tema || temaDoNavegador);
+  const [tema, setTema] = useState<Temas>('dark');
+
+  useEffect(() => {
+    const temaDoNavegador = window?.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light';
+    setTema(localStorage?.tema || temaDoNavegador);
+  }, [])
 
   return (
     <div className={tema}>


### PR DESCRIPTION
Mantém a solução de utilizar um useEffect para prevenir o localStorage e window iniciando como `undefined`.

Entretanto ao invés do tema inicial ser light, ele inicia no modo escuro e só então troca pro modo definido pelo usuário, pois uma transição dark -> light é bem mais amigável aos olhos do que uma light -> dark.

*Este pr arruma o problema da build